### PR TITLE
Set up adding new link feature

### DIFF
--- a/src/components/AddLink.tsx
+++ b/src/components/AddLink.tsx
@@ -1,27 +1,24 @@
-import { Link } from '@/utils/types/Link';
-import React from 'react'
+import { LinkPayload } from '@/generated/openapi';
+import { useAddLink } from '@/utils/hooks/useAddLink';
+import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
-type LinkInput = {
-    title: string;
-    url: string;
-}
-
 interface AddLinkProps {
-    onNewLink: (link: Link) => void;
 }
 
-export const AddLink: React.FC<AddLinkProps> = ({
-    onNewLink
-}) => {
-    const { register, handleSubmit } = useForm<LinkInput>();
+export const AddLink: React.FC<AddLinkProps> = ({}) => {
+    const { addLink } = useAddLink();
 
-    const onSubmit: SubmitHandler<LinkInput> = ({ title, url }) => {
-        onNewLink({ title, href: url });
+    const { register, handleSubmit } = useForm<LinkPayload>();
+    
+    const onSubmit: SubmitHandler<LinkPayload> = async (values) => {
+        addLink(values);
     }
 
     return (
-        <form 
+        <form
+        method='post'
+        action='http://localhost:8080/api/secure/links'
         className='flex flex-col w-full gap-1 mt-2'
         onSubmit={handleSubmit(onSubmit)}>
             <input 
@@ -38,6 +35,13 @@ export const AddLink: React.FC<AddLinkProps> = ({
                 type='url'
                 placeholder='Url'
                 {...register('url')}
+            />
+            <input 
+                className='p-2 border rounded-lg
+                shadow-inner shadow-slate-300'
+                type='text'
+                placeholder='Description'
+                {...register('description')}
             />
             <button 
                 className='bg-teal-400 p-2 rounded-lg

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -151,7 +151,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiLinkResponse'
-                  
+
+  /secure/links:
+    post:
+      summary: Add a new link
+      tags:
+        - Links
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'payload.yaml#/components/schemas/LinkPayload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean 
 
 security:
   - bearerAuth: []

--- a/src/specs/payload.yaml
+++ b/src/specs/payload.yaml
@@ -45,3 +45,15 @@ components:
           required:
             - sortKey
             - order
+    LinkPayload:
+      type: object
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+        description:
+          type: string
+      required:
+        - title
+        - url

--- a/src/utils/hooks/useAddLink.ts
+++ b/src/utils/hooks/useAddLink.ts
@@ -1,0 +1,35 @@
+import { LinkPayload } from "@/generated/openapi";
+import { useMutation } from "react-query";
+import { useCookie } from "./useCookie";
+
+export const useAddLink = () => {
+    const { cookie } = useCookie("linktree");
+
+    const headers = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Access-Control-Allow-Credentials": "true",
+        "Authorization": `Bearer ${cookie ? cookie : ""}`
+    }
+
+    const { mutateAsync, ...rest } = useMutation(
+        (payload: LinkPayload) => {
+            const requestOptions = {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(payload),
+            };
+            
+            return fetch("http://localhost:8080/api/secure/links", requestOptions);
+        }
+    );
+
+    const addLink = (payload: LinkPayload) => {
+        return mutateAsync(payload);
+    }
+
+    return {
+        addLink,
+        ...rest
+    }
+}

--- a/src/utils/openApi.ts
+++ b/src/utils/openApi.ts
@@ -27,6 +27,8 @@ const apiConfig: ConfigurationParameters = {
     basePath: 'http://localhost:8080/api',
     credentials: "include",
     headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
         "Access-Control-Allow-Credentials": "true"
     }
 }


### PR DESCRIPTION
- Create useAddLink hook that handles adding link to the database. Note: The "secureLinkPost" function that comes with the generated link api doesn't work. When we use it to fetch the post request, the server throws a "HttpMediaTypeNotSupportedException" because the request body is not of type "application/json" but of "text/plain". The "createParams" function inside the "request" function that comes with the generated api turns the body into plain text. So, we have to configure the fetch request from scratch.
