### PR TITLE
Fix useUpdate hook and update link display

### DIFF
--- a/src/components/EditableField.tsx
+++ b/src/components/EditableField.tsx
@@ -1,18 +1,17 @@
-import React from 'react'
-import { EditableText } from './EditableText';
+import React, { DetailedHTMLProps, InputHTMLAttributes } from 'react'
+import { EditableInput } from './EditableInput';
 
-interface EditableFieldProps {
+type EditableFieldProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
     field: string;
     initialValue: string;
-    textType: string;
     onEdit: (field: string, value: string) => void;
 }
 
 export const EditableField: React.FC<EditableFieldProps> = ({
     field,
     initialValue,
-    textType,
-    onEdit
+    onEdit,
+    ...rest
 }) => {
 
     const handleEdit = (value: string) => {
@@ -20,9 +19,9 @@ export const EditableField: React.FC<EditableFieldProps> = ({
     }
 
     return (
-        <EditableText
-            text={initialValue}
-            textType={textType}
+        <EditableInput
+            {...rest}
+            initialValue={initialValue}
             onEdit={handleEdit}
         />
     )

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -1,45 +1,44 @@
-import React, { useState } from "react";
+import React, { DetailedHTMLProps, InputHTMLAttributes, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { AiFillEdit, AiOutlineCheck, AiOutlineClose } from "react-icons/ai";
 
-interface EditableTextProps {
-  text: string;
-  textType?: string;
+type EditableInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
+  initialValue: string;
   onEdit: (value: string) => void;
 }
 
-export const EditableText: React.FC<EditableTextProps> = ({
-    text, textType='text', onEdit
+export const EditableInput: React.FC<EditableInputProps> = ({
+    initialValue, onEdit, ...rest
 }) => {
-    const [currentText, setCurrentText] = useState(text);
+    const [currentValue, setCurrentValue] = useState(initialValue);
 
     const { register, handleSubmit } = useForm<{ 
-        text: string 
-    }>({ values: { text: currentText } });
+        value: string 
+    }>({ values: { value: currentValue } });
 
     const [isEditable, setIsEditable] = useState(false);
 
-    const onSubmit: SubmitHandler<{ text: string }> = (values) => {
-        setCurrentText(values.text);
+    const onSubmit: SubmitHandler<{ value: string }> = ({ value }) => {
+        setCurrentValue(value);
         setIsEditable(false);
-        onEdit(values.text);
+        onEdit(value);
     }
 
     return (
         <>
         {isEditable ? (
             <form 
-            className='flex items-center gap-2'
+            className='flex items-center gap-2 w-full'
             onSubmit={handleSubmit(onSubmit)}>
                 <input
+                {...rest}   
                 autoFocus
                 className='ring-0 appearance-none
-                outline-none border-0 focus:ring
-                focus:ring-slate-200 rounded-sm'
-                placeholder='Title'
+                outline-none border-1 focus:ring px-1
+                focus:ring-slate-100 rounded-sm
+                bg-gray-200 w-full'
                 required
-                type={textType} 
-                {...register('text')} />
+                {...register('value')} />
                 <button className='font-bold' type='submit'>
                     <AiOutlineCheck size={15} />
                 </button>
@@ -50,7 +49,7 @@ export const EditableText: React.FC<EditableTextProps> = ({
         ):
         (<div className="flex items-center gap-2 group">
             <p className="text-center max-w-[130px] sm:max-w-full truncate">
-                {currentText}
+                {currentValue}
             </p>
             <button 
             className='opacity-0 group-hover:opacity-100 transition duration-200 ease-in-out'

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@/generated/openapi";
 import { useUpdate } from "@/utils/hooks/useUpdate";
-import Image from "next/image";
 import React from "react";
 import { AiFillDelete } from "react-icons/ai";
 import { HiExternalLink } from "react-icons/hi";
@@ -18,7 +17,6 @@ type LinkCardProps = {
 
 export const LinkCard: React.FC<LinkCardProps> = ({ 
     link,
-    imageSrc,
     onDelete
 }) => {
     const { updateLink } = useUpdate();
@@ -32,39 +30,17 @@ export const LinkCard: React.FC<LinkCardProps> = ({
 
     return (
         <div className="p-1 border shadow-md
-        rounded-lg flex items-center gap-2"
+        rounded-lg flex items-center gap-2 flex-wrap"
         >
-            {imageSrc ? (
-                <Image
-                className="rounded-lg aspect-square object-cover"
-                alt="user profile image"
-                src={imageSrc}
-                width={50}
-                height={50}
-                loading='lazy'
-                />
-            ) : (
-                <div className="bg-gray-400 w-[50px] h-[50px] rounded-lg" />
-            )}
-            <div className="flex flex-col max-w-[400px] flex-1 gap-1">
-                <span className="font-semibold">
-                    <EditableField 
-                    field="title"
-                    initialValue={link.title} 
-                    textType='text'
-                    onEdit={handleEdit}/>
-                </span>
-                {link.description && (
-                    <span className="text-gray-400 text-sm">
-                        <EditableField 
-                        field="description"
-                        textType="text"
-                        initialValue={link.description} 
-                        onEdit={handleEdit}/>
-                    </span>
-                )}
-            </div>
-            <div className="flex flex-row items-center mr-2 ml-auto gap-2">
+            <span className="font-semibold flex-1 px-1">
+                <EditableField 
+                field="title"
+                initialValue={link.title} 
+                type="text"
+                placeholder="Title"
+                onEdit={handleEdit}/>
+            </span>
+            <div className="flex flex-row items-center mr-2 gap-2">
                 <a href={link.url}>
                     <HiExternalLink size={15} />
                 </a>

--- a/src/utils/generateRequestHeaders.ts
+++ b/src/utils/generateRequestHeaders.ts
@@ -1,0 +1,6 @@
+export const generateRequestHeaders = (cookie: string | null) => ({
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "Access-Control-Allow-Credentials": "true",
+    "Authorization": `Bearer ${cookie ? cookie : ""}`
+});

--- a/src/utils/hooks/useAddLink.ts
+++ b/src/utils/hooks/useAddLink.ts
@@ -1,24 +1,18 @@
 import { useLinkContext } from "@/contexts/LinkContext";
 import { LinkPayload } from "@/generated/openapi";
 import { useMutation } from "react-query";
+import { generateRequestHeaders } from "../generateRequestHeaders";
 import { useCookie } from "./useCookie";
 
 export const useAddLink = () => {
     const { cookie } = useCookie("linktree");
     const { refetchLinks } = useLinkContext();
 
-    const headers = {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Access-Control-Allow-Credentials": "true",
-        "Authorization": `Bearer ${cookie ? cookie : ""}`
-    }
-
     const { mutateAsync, ...rest } = useMutation(
         (payload: LinkPayload) => {
             const requestOptions = {
                 method: 'POST',
-                headers,
+                headers: generateRequestHeaders(cookie),
                 body: JSON.stringify(payload),
             };
             

--- a/src/utils/hooks/useUpdate.ts
+++ b/src/utils/hooks/useUpdate.ts
@@ -1,18 +1,25 @@
 import { LinkPayload, SecureLinkIdPutRequest } from "@/generated/openapi";
 import { useMutation, useQueryClient } from "react-query";
-import { linksApi } from "../openApi";
+import { generateRequestHeaders } from "../generateRequestHeaders";
+import { useCookie } from "./useCookie";
 
 type UpdatePayload = SecureLinkIdPutRequest;
 
 export const useUpdate = () => {
+    const { cookie } = useCookie("linktree");
+    
     const queryClient = useQueryClient();
 
     const { mutateAsync, ...rest } = useMutation(
-        ({ id, linkPayload: newLink }: UpdatePayload) => 
-            linksApi.withPreMiddleware().secureLinkIdPut({
-                id, 
-                linkPayload: newLink
-            }),
+        ({ id, linkPayload: newLink }: UpdatePayload) => {
+            const requestOptions = {
+                method: 'PUT',
+                headers: generateRequestHeaders(cookie),
+                body: JSON.stringify(newLink),
+            };
+            
+            return fetch(`http://localhost:8080/api/secure/link/${id}`, requestOptions);
+        },
         {
             onSuccess: (data, variables) => {
                 queryClient.setQueryData(


### PR DESCRIPTION
- The generated secureLinkIdPut function from OpenAPI doesn't work due to the conflicting type of the request body. It keeps throwing the HttpMediaTypeNotSupportedException ("Content-Type 'text/plain;charset=UTF-8' is not supported") in the backend. So I decided to write the update function manually using fetch api.
- Remove image from link display
- Show only the title of each link